### PR TITLE
Add OpenAI multi-agent marketing example

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -1,0 +1,31 @@
+# Multi-agent product copy example
+
+This directory contains a sample script showing how to use the OpenAI agent SDK
+to orchestrate multiple agents. The `product_copy_agents.py` script demonstrates
+how marketing copy can be generated, evaluated via a simulated A/B test and the
+results fed back to improve future prompts.
+
+## Architecture
+
+![Multi-agent architecture](multi_agent_architecture.svg)
+
+Editable diagram source: `multi_agent_architecture.drawio`
+
+## Usage
+
+1. Install dependencies:
+
+```bash
+pip install openai
+```
+
+2. Set the `OPENAI_API_KEY` environment variable.
+
+3. Run the example:
+
+```bash
+python agents/product_copy_agents.py
+```
+
+The script prints the final optimized prompt after a couple of optimization
+rounds.

--- a/agents/multi_agent_architecture.drawio
+++ b/agents/multi_agent_architecture.drawio
@@ -1,0 +1,40 @@
+<mxfile host="app.diagrams.net" version="20.8.16" type="device" compressed="false">
+  <diagram id="multi_agent" name="Multi Agent">
+    <mxGraphModel dx="800" dy="600">
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+        <mxCell id="PO" value="PromptOptimizer" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;" vertex="1" parent="1">
+          <mxGeometry x="40" y="40" width="120" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="CW" value="CopyWriterAgent" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;" vertex="1" parent="1">
+          <mxGeometry x="240" y="40" width="120" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="AB" value="ABTesterAgent" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="1">
+          <mxGeometry x="440" y="40" width="120" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="FB" value="FeedbackAgent" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
+          <mxGeometry x="640" y="40" width="120" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="PI" value="Product info" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;" vertex="1" parent="1">
+          <mxGeometry x="240" y="140" width="120" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="e1" source="PO" target="CW" edge="1" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="e2" source="CW" target="AB" edge="1" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="e3" source="AB" target="FB" edge="1" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="e4" source="FB" target="PO" edge="1" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="e5" source="PI" target="CW" edge="1" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/agents/multi_agent_architecture.svg
+++ b/agents/multi_agent_architecture.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="200">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="10" refY="3" orient="auto">
+      <path d="M0,0 L10,3 L0,6 Z" fill="#333" />
+    </marker>
+  </defs>
+  <rect x="40" y="40" width="120" height="50" fill="#dae8fc" stroke="#6c8ebf" />
+  <text x="100" y="70" text-anchor="middle" font-size="12" font-family="sans-serif">PromptOptimizer</text>
+  <rect x="240" y="40" width="120" height="50" fill="#d5e8d4" stroke="#82b366" />
+  <text x="300" y="70" text-anchor="middle" font-size="12" font-family="sans-serif">CopyWriterAgent</text>
+  <rect x="440" y="40" width="120" height="50" fill="#f8cecc" stroke="#b85450" />
+  <text x="500" y="70" text-anchor="middle" font-size="12" font-family="sans-serif">ABTesterAgent</text>
+  <rect x="640" y="40" width="120" height="50" fill="#fff2cc" stroke="#d6b656" />
+  <text x="700" y="70" text-anchor="middle" font-size="12" font-family="sans-serif">FeedbackAgent</text>
+  <rect x="240" y="140" width="120" height="50" fill="#e1d5e7" stroke="#9673a6" />
+  <text x="300" y="170" text-anchor="middle" font-size="12" font-family="sans-serif">Product info</text>
+  <line x1="160" y1="65" x2="240" y2="65" stroke="#333" marker-end="url(#arrow)" />
+  <line x1="360" y1="65" x2="440" y2="65" stroke="#333" marker-end="url(#arrow)" />
+  <line x1="560" y1="65" x2="640" y2="65" stroke="#333" marker-end="url(#arrow)" />
+  <line x1="760" y1="90" x2="100" y2="90" stroke="#333" marker-end="url(#arrow)" />
+  <line x1="300" y1="140" x2="300" y2="90" stroke="#333" marker-end="url(#arrow)" />
+</svg>

--- a/agents/product_copy_agents.py
+++ b/agents/product_copy_agents.py
@@ -1,0 +1,87 @@
+"""Example multi-agent pipeline using the OpenAI agent SDK.
+
+The script shows how to orchestrate agents for marketing copy generation,
+simulated A/B testing, and prompt improvement through feedback.
+"""
+from __future__ import annotations
+
+import random
+from typing import Dict, List
+
+from openai import OpenAI
+
+
+class CopyWriterAgent:
+    """Agent responsible for generating marketing copy variants."""
+
+    def __init__(self, client: OpenAI, model: str = "gpt-4.1-mini") -> None:
+        self.client = client
+        self.model = model
+
+    def generate_copies(self, product: str, prompt_template: str, n: int = 2) -> List[str]:
+        """Return *n* candidate copies using the provided template."""
+        prompt = prompt_template.format(product=product, n=n)
+        response = self.client.responses.create(model=self.model, input=prompt)
+        lines = [line.strip("- ") for line in response.output_text.splitlines() if line.strip()]
+        return lines[:n]
+
+
+class ABTesterAgent:
+    """Agent that performs a dummy A/B test by simulating conversion rates."""
+
+    def run(self, copies: List[str]) -> Dict[str, float]:
+        return {copy: random.random() for copy in copies}
+
+
+class FeedbackAgent:
+    """Agent that proposes a better prompt template using feedback."""
+
+    def __init__(self, client: OpenAI, model: str = "gpt-4.1-mini") -> None:
+        self.client = client
+        self.model = model
+
+    def improve_prompt(self, template: str, results: Dict[str, float]) -> str:
+        best_copy = max(results, key=results.get)
+        feedback_prompt = (
+            "The following marketing copy performed best in an A/B test:\n"
+            f"{best_copy}\n\n"
+            "Original prompt template:\n"
+            f"{template}\n\n"
+            "Suggest an improved prompt template that could yield better copies."
+        )
+        response = self.client.responses.create(model=self.model, input=feedback_prompt)
+        return response.output_text.strip()
+
+
+class PromptOptimizer:
+    """High level loop that iteratively updates the prompt template."""
+
+    def __init__(self, copy_agent: CopyWriterAgent, tester: ABTesterAgent,
+                 fb_agent: FeedbackAgent, template: str) -> None:
+        self.copy_agent = copy_agent
+        self.tester = tester
+        self.fb_agent = fb_agent
+        self.template = template
+
+    def optimize(self, product: str, rounds: int = 3) -> str:
+        for _ in range(rounds):
+            copies = self.copy_agent.generate_copies(product, self.template)
+            results = self.tester.run(copies)
+            self.template = self.fb_agent.improve_prompt(self.template, results)
+        return self.template
+
+
+def main() -> None:
+    client = OpenAI()
+    copy_agent = CopyWriterAgent(client)
+    tester = ABTesterAgent()
+    fb_agent = FeedbackAgent(client)
+    template = "Generate {n} short, catchy marketing copies for {product}." \
+               "Each copy should be under 20 words."
+    optimizer = PromptOptimizer(copy_agent, tester, fb_agent, template)
+    final_template = optimizer.optimize("wireless earbuds", rounds=2)
+    print("Final optimized prompt:\n", final_template)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `product_copy_agents.py` demonstrating multi-agent workflow with OpenAI Agent SDK
- document architecture with a draw.io diagram linked from README

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbdedc6398832f8c3a5df96090a47d